### PR TITLE
Default to use `rustls-tls`

### DIFF
--- a/exc-binance/Cargo.toml
+++ b/exc-binance/Cargo.toml
@@ -11,7 +11,7 @@ description = "Binance exchange services"
 keywords = ["exchange", "tower", "binance"]
 
 [features]
-default = ["native-tls"]
+default = ["rustls-tls"]
 native-tls = ["exc-core/native-tls", "tokio-tungstenite/native-tls"]
 rustls-tls = ["exc-core/rustls-tls", "tokio-tungstenite/rustls-tls-webpki-roots"]
 ci = []

--- a/exc-core/Cargo.toml
+++ b/exc-core/Cargo.toml
@@ -11,9 +11,9 @@ rust-version.workspace = true
 readme = "./README.md"
 
 [features]
-default = ["websocket", "http", "retry", "native-tls"]
-native-tls = ["tokio-tungstenite/native-tls", "hyper-tls"]
-rustls-tls = ["tokio-tungstenite/rustls-tls-webpki-roots", "hyper-rustls"]
+default = ["websocket", "http", "retry", "rustls-tls"]
+native-tls = ["tokio-tungstenite?/native-tls", "hyper-tls"]
+rustls-tls = ["tokio-tungstenite?/rustls-tls-webpki-roots", "hyper-rustls"]
 websocket = ["tokio-tungstenite", "dep:http", "tokio/net"]
 driven = ["tokio/sync", "tokio/rt", "pin-project-lite"]
 http = ["hyper/client", "hyper/http1", "dep:http"]

--- a/exc-core/src/transport/http/channel.rs
+++ b/exc-core/src/transport/http/channel.rs
@@ -1,39 +1,44 @@
-use crate::ExchangeError;
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
-use http::{Request, Response};
-use hyper::{client::HttpConnector, Body, Client};
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+pub use https::HttpsChannel;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "native-tls")] {
-        use hyper_tls::HttpsConnector;
-    } else if #[cfg(feature = "rustls-tls")] {
-        use hyper_rustls::HttpsConnector;
-    } else {
-        compile_error!{"Not support TLS"}
-    }
-}
-
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 /// Https channel.
-#[derive(Clone)]
-pub struct HttpsChannel {
-    pub(crate) inner: Client<HttpsConnector<HttpConnector>>,
-}
+pub mod https {
+    use crate::ExchangeError;
+    use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+    use http::{Request, Response};
+    use hyper::{client::HttpConnector, Body, Client};
 
-impl tower::Service<Request<Body>> for HttpsChannel {
-    type Response = Response<Body>;
-    type Error = ExchangeError;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(ExchangeError::Http)
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "native-tls")] {
+            use hyper_tls::HttpsConnector;
+        } else if #[cfg(feature = "rustls-tls")] {
+            use hyper_rustls::HttpsConnector;
+        }
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
-        tower::Service::call(&mut self.inner, req)
-            .map_err(ExchangeError::Http)
-            .boxed()
+    /// Https channel.
+    #[derive(Clone)]
+    pub struct HttpsChannel {
+        pub(crate) inner: Client<HttpsConnector<HttpConnector>>,
+    }
+
+    impl tower::Service<Request<Body>> for HttpsChannel {
+        type Response = Response<Body>;
+        type Error = ExchangeError;
+        type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx).map_err(ExchangeError::Http)
+        }
+
+        fn call(&mut self, req: Request<Body>) -> Self::Future {
+            tower::Service::call(&mut self.inner, req)
+                .map_err(ExchangeError::Http)
+                .boxed()
+        }
     }
 }

--- a/exc-core/src/transport/http/endpoint.rs
+++ b/exc-core/src/transport/http/endpoint.rs
@@ -1,36 +1,38 @@
 use hyper::client::Builder;
 
-use super::channel::HttpsChannel;
-
 /// Endpoint.
 #[derive(Debug, Default)]
 pub struct Endpoint {
     inner: Builder,
 }
 
-impl Endpoint {
-    /// Create a https channel.
-    pub fn connect_https(&self) -> HttpsChannel {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "native-tls")] {
-                let https = hyper_tls::HttpsConnector::new();
-            } else if #[cfg(feature = "rustls-tls")] {
-                let https = hyper_rustls::HttpsConnectorBuilder::new()
-                    .with_webpki_roots()
-                    .https_or_http()
-                    .enable_http1()
-                    .build();
-            } else {
-                compile_error!{"Not support TLS"}
-            }
-        }
-        let client = self.inner.build(https);
-        HttpsChannel { inner: client }
-    }
-}
-
 impl From<Builder> for Endpoint {
     fn from(inner: Builder) -> Self {
         Self { inner }
+    }
+}
+
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+mod https {
+    use super::*;
+    use crate::transport::http::channel::HttpsChannel;
+
+    impl Endpoint {
+        /// Create a https channel.
+        pub fn connect_https(&self) -> HttpsChannel {
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "native-tls")] {
+                    let https = hyper_tls::HttpsConnector::new();
+                } else if #[cfg(feature = "rustls-tls")] {
+                    let https = hyper_rustls::HttpsConnectorBuilder::new()
+                        .with_webpki_roots()
+                        .https_or_http()
+                        .enable_http1()
+                        .build();
+                }
+            }
+            let client = self.inner.build(https);
+            HttpsChannel { inner: client }
+        }
     }
 }

--- a/exc-okx/Cargo.toml
+++ b/exc-okx/Cargo.toml
@@ -11,7 +11,7 @@ description = "OKX exchange services"
 keywords = ["exchange", "tower", "okx"]
 
 [features]
-default = ["native-tls"]
+default = ["rustls-tls"]
 native-tls = ["exc-core/native-tls", "tokio-tungstenite/native-tls"]
 rustls-tls = ["exc-core/rustls-tls", "tokio-tungstenite/rustls-tls-webpki-roots"]
 prefer-client-id = []

--- a/exc/Cargo.toml
+++ b/exc/Cargo.toml
@@ -11,7 +11,7 @@ description.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["websocket", "http", "retry", "native-tls"]
+default = ["websocket", "http", "retry", "rustls-tls"]
 native-tls = ["exc-core/native-tls", "exc-okx/native-tls", "exc-binance/native-tls"]
 rustls-tls = ["exc-core/rustls-tls", "exc-okx/rustls-tls", "exc-binance/rustls-tls"]
 okx = ["exc-okx"]


### PR DESCRIPTION
Perhaps using `rustls-tls` as the default feature would be better? For it doesn't have system dependencies like `openssl`.